### PR TITLE
SP2-2138: Remove sp-enable-teams-report-problem-link

### DIFF
--- a/flags/dev/hmpps-arns-assessment-platform/features.yml
+++ b/flags/dev/hmpps-arns-assessment-platform/features.yml
@@ -11,7 +11,3 @@ flags:
       name: sp-enable-smart-survey-in-national-rollout
       type: BOOLEAN_FLAG_TYPE
       enabled: false
-    - key: sp-enable-teams-report-problem-link
-      name: sp-enable-teams-report-problem-link
-      type: BOOLEAN_FLAG_TYPE
-      enabled: false

--- a/flags/preprod/hmpps-arns-assessment-platform/features.yml
+++ b/flags/preprod/hmpps-arns-assessment-platform/features.yml
@@ -11,4 +11,3 @@ flags:
       name: sp-enable-smart-survey-in-national-rollout
       type: BOOLEAN_FLAG_TYPE
       enabled: false
-

--- a/flags/preprod/hmpps-arns-assessment-platform/features.yml
+++ b/flags/preprod/hmpps-arns-assessment-platform/features.yml
@@ -11,7 +11,4 @@ flags:
       name: sp-enable-smart-survey-in-national-rollout
       type: BOOLEAN_FLAG_TYPE
       enabled: false
-    - key: sp-enable-teams-report-problem-link
-      name: sp-enable-teams-report-problem-link
-      type: BOOLEAN_FLAG_TYPE
-      enabled: false
+

--- a/flags/prod/hmpps-arns-assessment-platform/features.yml
+++ b/flags/prod/hmpps-arns-assessment-platform/features.yml
@@ -11,7 +11,3 @@ flags:
       name: sp-enable-smart-survey-in-national-rollout
       type: BOOLEAN_FLAG_TYPE
       enabled: false
-    - key: sp-enable-teams-report-problem-link
-      name: sp-enable-teams-report-problem-link
-      type: BOOLEAN_FLAG_TYPE
-      enabled: false


### PR DESCRIPTION
Removes the sp-enable-teams-report-problem-link feature flag from dev, preprod and prod. The flag is no longer used: the Teams report-problem link has been deprecated in favour of ServiceNow, and all mentions in `hmpps-arns-assessment-platform-ui` are removed in [SP2-2138 PR](https://github.com/ministryofjustice/hmpps-arns-assessment-platform-ui/pull/515).