### PR TITLE
enabled metadata retrival in dev

### DIFF
--- a/flipt/config/dev.yml
+++ b/flipt/config/dev.yml
@@ -66,3 +66,6 @@ environments:
     storage: "main"
     default: true
     directory: "flags/dev"
+
+evaluation:
+  include_flag_metadata: true


### PR DESCRIPTION
The SDK's `listFlags()` method in Flipt v1 returned a full list of flags with description which was being used in the consider-a-recall service to provide an interface for users to enable flags locally. In Flipt v2 this has been disabled by default, this PR will re-enable it.

This is the configuration option:
https://docs.flipt.io/v2/configuration/overview#evaluation