### PR TITLE
Add Dependabot config and fix the Snyk scan

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  # The Flipt base image in flipt/Dockerfile.
+  - package-ecosystem: docker
+    directory: /flipt
+    schedule:
+      interval: weekly
+
+  # The smoke test suite's npm dependencies.
+  - package-ecosystem: npm
+    directory: /tests
+    schedule:
+      interval: weekly
+
+  # SHA-pinned actions in .github/workflows. The hmpps-github-actions reusable
+  # workflows are versioned by HMPPS's own WORKFLOW_VERSION process, so leave
+  # them alone.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    ignore:
+      - dependency-name: ministryofjustice/hmpps-github-actions

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -52,7 +52,7 @@ jobs:
   opa_test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           persist-credentials: false
       - shell: bash
@@ -69,7 +69,7 @@ jobs:
   opa_lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           persist-credentials: false
       - shell: bash
@@ -87,7 +87,7 @@ jobs:
   smoke_test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           persist-credentials: false
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0

--- a/.github/workflows/security_snyk_scan.yml
+++ b/.github/workflows/security_snyk_scan.yml
@@ -17,7 +17,7 @@ jobs:
       channel_id: ${{ vars.SECURITY_ALERTS_SLACK_CHANNEL_ID || 'NO_SLACK' }}
       subproject: ''
       severity: 'HIGH,CRITICAL'
-      scan_type: 'fs' # or 'image'
+      scan_type: 'image'
       location: '.'
       slack_include_summary: true
       snyk_policy_path: ''


### PR DESCRIPTION
- Add weekly Dependabot `docker` updates on `flipt/Dockerfile`, covering the `ghcr.io/flipt-io/flipt` image
- Add weekly `npm` updates for the smoke test suite in `tests/`
- Add weekly `github-actions` updates for the pinned `checkout`/`setup-go`/`setup-node`, ignoring the `hmpps-github-actions@v2` reusable workflows - those are versioned by HMPPS's own WORKFLOW_VERSION process
- Add the missing `# v5.0.0` comments to the `pipeline.yml` checkout pins so Dependabot keeps them in sync
- Switch the Snyk scan to `scan_type: 'image'` so it tests `ghcr.io/ministryofjustice/hmpps-feature-flags:latest` - the Flipt binary and alpine packages we actually ship - instead of finding nothing