### PR TITLE
Add opt-in prod self-service flag approval bot

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -16,9 +16,3 @@ flags/*/hmpps-electronic-monitoring-data-insights/  @ministryofjustice/hmpps-em-
 flags/*/manage-people-on-probation-ui/              @ministryofjustice/hmpps-manage-people-on-probation-dev
 flags/*/prisoner-finance/                           @ministryofjustice/hmpps-prisoner-finance-dev
 flags/*/probation-integration/                      @ministryofjustice/probation-integration
-
-# Prod self-service namespaces (see README)
-# A namespace with `prodSelfService: true` also needs a line here with no
-# owner - it clears ownership so the flag-approval bot's review can satisfy
-# branch protection. Example:
-# flags/*/my-namespace/

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -16,3 +16,9 @@ flags/*/hmpps-electronic-monitoring-data-insights/  @ministryofjustice/hmpps-em-
 flags/*/manage-people-on-probation-ui/              @ministryofjustice/hmpps-manage-people-on-probation-dev
 flags/*/prisoner-finance/                           @ministryofjustice/hmpps-prisoner-finance-dev
 flags/*/probation-integration/                      @ministryofjustice/probation-integration
+
+# Prod self-service namespaces (see README)
+# A namespace with `prodSelfService: true` also needs a line here with no
+# owner - it clears ownership so the flag-approval bot's review can satisfy
+# branch protection. Example:
+# flags/*/my-namespace/

--- a/.github/workflows/flag_approval.yml
+++ b/.github/workflows/flag_approval.yml
@@ -136,7 +136,7 @@ jobs:
 
               const teamList = [...teams].map((team) => `@ministryofjustice/${team}`).join(', ')
 
-              body = `${MARKER}\n⏳ **Needs approval from ${teamList}** - this PR touches files that require review (CODEOWNERS enforces this).`
+              body = `${MARKER}\n⏳ **Needs approval from ${teamList}** - this PR touches files that require a human review.`
             }
 
             const comments = await github.paginate(github.rest.issues.listComments, {

--- a/.github/workflows/flag_approval.yml
+++ b/.github/workflows/flag_approval.yml
@@ -1,0 +1,153 @@
+# Auto-approves PRs that only change flags in namespaces that have opted in
+# to prod self-service (`prodSelfService: true` in flags/prod/{ns}/access.yml),
+# and comments on other flag PRs naming the team whose approval is needed.
+#
+# Runs on pull_request_target so the policy below always executes from main,
+# and the opt-ins are read from main's checkout - a PR can't opt itself in.
+# No code from the PR branch is ever executed here.
+name: Flag Approval
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  flag_approval:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            const fs = require('fs')
+
+            const MARKER = '<!-- flag-approval-bot -->'
+            const ADMIN_TEAM = 'hmpps-feature-flag-admins'
+            const BOT_LOGIN = 'github-actions[bot]'
+
+            const pr = context.payload.pull_request
+            const repo = { owner: context.repo.owner, repo: context.repo.repo }
+
+            // access.yml is canonical-formatted (enforced by make flags-lint),
+            // so a light regex parse is safe here.
+            const readProdAccess = (namespace) => {
+              const path = `flags/prod/${namespace}/access.yml`
+              if (!fs.existsSync(path)) {
+                return undefined
+              }
+
+              const content = fs.readFileSync(path, 'utf8')
+
+              return {
+                writers: [...content.matchAll(/^\s+-\s+(\S+)\s*$/gm)].map((m) => m[1]),
+                selfService: /^prodSelfService:\s*true\s*$/m.test(content),
+              }
+            }
+
+            const changedFiles = await github.paginate(github.rest.pulls.listFiles, {
+              ...repo,
+              pull_number: pr.number,
+              per_page: 100,
+            })
+
+            const flagFilePattern = /^flags\/(dev|preprod|prod)\/([^/]+)\/features\.ya?ml$/
+            const namespaces = new Set()
+            let onlyFlagFiles = changedFiles.length > 0
+
+            for (const file of changedFiles) {
+              const paths = [file.filename, file.previous_filename].filter(Boolean)
+
+              for (const path of paths) {
+                const match = path.match(flagFilePattern)
+
+                if (match) {
+                  namespaces.add(match[2])
+                } else {
+                  onlyFlagFiles = false
+                }
+              }
+            }
+
+            const accessByNamespace = new Map(
+              [...namespaces].map((namespace) => [namespace, readProdAccess(namespace)]),
+            )
+
+            const allSelfService =
+              namespaces.size > 0 &&
+              [...accessByNamespace.values()].every((access) => access?.selfService)
+
+            const { data: permission } = await github.rest.repos.getCollaboratorPermissionLevel({
+              ...repo,
+              username: pr.user.login,
+            })
+            const authorHasWrite = ['admin', 'maintain', 'write'].includes(permission.permission)
+
+            const eligible = onlyFlagFiles && allSelfService && authorHasWrite
+
+            const reviews = await github.paginate(github.rest.pulls.listReviews, {
+              ...repo,
+              pull_number: pr.number,
+              per_page: 100,
+            })
+            const botApprovals = reviews.filter(
+              (review) => review.user?.login === BOT_LOGIN && review.state === 'APPROVED',
+            )
+
+            let body
+
+            if (eligible) {
+              const namespaceList = [...namespaces].map((ns) => `\`${ns}\``).join(', ')
+
+              if (!botApprovals.some((review) => review.commit_id === pr.head.sha)) {
+                await github.rest.pulls.createReview({
+                  ...repo,
+                  pull_number: pr.number,
+                  event: 'APPROVE',
+                  body: `Auto-approved: all changes are flag changes in prod self-service namespaces (${namespaceList}).`,
+                })
+              }
+
+              body = `${MARKER}\n✅ **Namespace has prod self-approval** - this PR only changes flags in ${namespaceList}, which opted in via \`prodSelfService: true\`. No review needed, merge when the checks are green.`
+            } else {
+              // A previous head of this PR may have been auto-approved, or the
+              // namespace may have opted out on main since - withdraw it.
+              for (const review of botApprovals.filter((r) => r.commit_id === pr.head.sha)) {
+                await github.rest.pulls.dismissReview({
+                  ...repo,
+                  pull_number: pr.number,
+                  review_id: review.id,
+                  message: 'PR is no longer eligible for prod self-approval.',
+                })
+              }
+
+              const teams = new Set(
+                [...accessByNamespace.values()].flatMap((access) => access?.writers ?? [ADMIN_TEAM]),
+              )
+
+              if (!onlyFlagFiles) {
+                teams.add(ADMIN_TEAM)
+              }
+
+              const teamList = [...teams].map((team) => `@ministryofjustice/${team}`).join(', ')
+
+              body = `${MARKER}\n⏳ **Needs approval from ${teamList}** - this PR touches files that require review (CODEOWNERS enforces this).`
+            }
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              ...repo,
+              issue_number: pr.number,
+              per_page: 100,
+            })
+            const existing = comments.find((comment) => comment.body?.includes(MARKER))
+
+            if (existing) {
+              await github.rest.issues.updateComment({ ...repo, comment_id: existing.id, body })
+            } else {
+              await github.rest.issues.createComment({ ...repo, issue_number: pr.number, body })
+            }

--- a/README.md
+++ b/README.md
@@ -85,6 +85,34 @@ go through a Git PR:
 > [!TIP]
 > You don't need to edit YAML by hand. The Flipt UI has a **Create branch** feature that lets you make flag changes visually on a new branch. Once you're happy with the changes, raise a PR from that branch for your team to review.
 
+### Skipping PR approval (prod self-service)
+
+Some teams don't want an approval step between them and a prod flag change. 
+A namespace can opt in to self-service, which keeps the PR flow (and all the 
+CI checks) but removes the need for a human review. To opt in, raise a PR that:
+
+1. Adds `prodSelfService: true` to `flags/prod/{namespace}/access.yml`
+2. Adds a line for your namespace to the self-service section at the bottom of 
+   `.github/CODEOWNERS` - a path with no owner, e.g. `flags/*/my-namespace/`
+
+That PR needs approval from the feature flag admins - it's the last one that does.
+
+From then on, the flag-approval bot approves any PR that only changes 
+`features.yml` files in opted-in namespaces, and comments 
+"Namespace has prod self-approval". Raise your PR, wait for the checks, merge.
+
+The bot only steps in when it's safe to:
+
+- Any other file in the PR (`access.yml`, another team's namespace, anything 
+  outside `flags/`) means no auto-approval - the bot instead comments with the 
+  team whose approval is needed
+- Opt-ins are read from `main`, so a PR can't opt itself in
+- The PR author needs write access to this repo
+
+This is a trust-based scheme: it assumes nobody with write access is actively 
+trying to game the review process. If that assumption ever stops holding, the 
+approval needs to move to a dedicated GitHub App identity instead.
+
 ## Evaluating flags
 
 The recommended approach is to use 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ go through a Git PR:
 2. Add or update your flags in `flags/prod/{namespace}/features.yml`
 3. Run `make flags-lint` to validate your changes
 4. Push the branch and raise a PR
-5. Get approval from your team (CODEOWNERS enforces team-level review)
+5. Get approval from your team (CODEOWNERS requests the review automatically)
 6. Merge to `main` — the change will deploy automatically through dev -> preprod -> prod
 
 > [!TIP]
@@ -89,13 +89,10 @@ go through a Git PR:
 
 Some teams don't want an approval step between them and a prod flag change. 
 A namespace can opt in to self-service, which keeps the PR flow (and all the 
-CI checks) but removes the need for a human review. To opt in, raise a PR that:
+CI checks) but removes the need for a human review. To opt in, raise a PR 
+adding `prodSelfService: true` to `flags/prod/{namespace}/access.yml`.
 
-1. Adds `prodSelfService: true` to `flags/prod/{namespace}/access.yml`
-2. Adds a line for your namespace to the self-service section at the bottom of 
-   `.github/CODEOWNERS` - a path with no owner, e.g. `flags/*/my-namespace/`
-
-That PR needs approval from the feature flag admins - it's the last one that does.
+That PR needs a human approval - it's the last one that does.
 
 From then on, the flag-approval bot approves any PR that only changes 
 `features.yml` files in opted-in namespaces, and comments 

--- a/README.md
+++ b/README.md
@@ -109,10 +109,6 @@ The bot only steps in when it's safe to:
 - Opt-ins are read from `main`, so a PR can't opt itself in
 - The PR author needs write access to this repo
 
-This is a trust-based scheme: it assumes nobody with write access is actively 
-trying to game the review process. If that assumption ever stops holding, the 
-approval needs to move to a dedicated GitHub App identity instead.
-
 ## Evaluating flags
 
 The recommended approach is to use 


### PR DESCRIPTION
A team asked to change prod flags through GitHub without waiting for a PR approval. Currently every prod change needs a human review, and branch protection can't waive that per-path - so this adds an opt-in auto-approval bot, with a namespace opting in via a single `prodSelfService: true` key in its prod `access.yml`.

- Add a `Flag Approval` workflow that approves PRs only touching `features.yml` files in opted-in namespaces, commenting "Namespace has prod self-approval"
- Comment "Needs approval from @team" on everything else, derived from the namespace's `writers`
- Run on `pull_request_target` with opt-ins read from `main`'s checkout, so a PR can't opt itself in and no PR-branch code runs
- Never auto-approve `access.yml` changes - opting in (and any writer change) still needs a human review
- Require the PR author to have write access
- Dismiss the bot's approval if a later push makes the PR ineligible
- Document the opt-in in the README

Needs one branch protection change when this lands: turn off `require_code_owner_reviews`, so the bot's approval alone satisfies the review requirement. CODEOWNERS stays as-is and keeps auto-requesting the right team on every PR - it just routes rather than enforces.
